### PR TITLE
test: use oss image where possible

### DIFF
--- a/src/test/java/io/kestra/plugin/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/AbstractKestraContainerTest.java
@@ -3,38 +3,50 @@ package io.kestra.plugin;
 import io.kestra.sdk.internal.ApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 
 @Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Slf4j
-public class AbstractKestraContainerTest {
-    protected static final String USERNAME = "admin@admin.com";
-    protected static final String PASSWORD = "Root!1234";
-    protected static final String TENANT_ID = "main";
-    protected static String KESTRA_URL;
+public abstract class AbstractKestraContainerTest {
+    protected final String USERNAME = "admin@admin.com";
+    protected final String PASSWORD = "Root!1234";
+    protected final String TENANT_ID = "main";
 
-    protected static KestraTestDataUtils kestraTestDataUtils;
+    protected String KESTRA_URL;
+    protected KestraTestDataUtils kestraTestDataUtils;
 
-    @Container
-    protected static GenericContainer<?> kestraContainer =
-        new GenericContainer<>(
-            DockerImageName.parse("ghcr.io/kestra-io/kestra-ee:develop"))
+    protected abstract GenericContainer<?> getContainer();
+
+    @BeforeAll
+    void setupKestra() throws ApiException {
+        GenericContainer<?> kestraContainer = getContainer();
+        kestraContainer.start();
+
+        KESTRA_URL = "http://" + kestraContainer.getHost() + ":" + kestraContainer.getMappedPort(8080);
+        log.info("Kestra started at URL: {}", KESTRA_URL);
+
+        kestraTestDataUtils = new KestraTestDataUtils(KESTRA_URL, USERNAME, PASSWORD, TENANT_ID);
+    }
+
+    protected GenericContainer<?> buildContainer(String image, boolean ee) {
+        GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse(image))
             .withExposedPorts(8080)
             .withEnv("KESTRA_SECURITY_SUPER_ADMIN_USERNAME", USERNAME)
             .withEnv("KESTRA_SECURITY_SUPER_ADMIN_PASSWORD", PASSWORD)
-            .withEnv("KESTRA_EE_LICENSE_PUBLICKEY", System.getenv("KESTRA_EE_LICENSE_PUBLICKEY"))
-            .withEnv("KESTRA_EE_LICENSE_KEY", System.getenv("KESTRA_EE_LICENSE_KEY"))
-            .withEnv("KESTRA_EE_LICENSE_ID", System.getenv("KESTRA_EE_LICENSE_ID"))
-            .withEnv("KESTRA_CONFIGURATION",
-                """
+            .withEnv("KESTRA_CONFIGURATION", """
                 kestra:
+                  server:
+                    basic-auth:
+                      username: admin@admin.com
+                      password: Root!1234
                   ee:
                     tenants:
                       enabled: false
@@ -52,24 +64,17 @@ public class AbstractKestraContainerTest {
                       tenantAdminAccess: main
                 """)
             .withCommand("server local")
-            .waitingFor(
-                Wait.forHttp("/ui/login")
-                    .forStatusCode(200)
-            )
+            .waitingFor(Wait.forHttp("/ui/login").forStatusCode(200))
             .withLogConsumer(new Slf4jLogConsumer(log))
             .withStartupTimeout(Duration.ofMinutes(2));
 
-    @BeforeAll
-    static void setupKestra() throws ApiException {
-        KESTRA_URL = "http://" + kestraContainer.getHost() + ":" + kestraContainer.getMappedPort(8080);
+        if (ee) {
+            container
+                .withEnv("KESTRA_EE_LICENSE_PUBLICKEY", System.getenv("KESTRA_EE_LICENSE_PUBLICKEY"))
+                .withEnv("KESTRA_EE_LICENSE_KEY", System.getenv("KESTRA_EE_LICENSE_KEY"))
+                .withEnv("KESTRA_EE_LICENSE_ID", System.getenv("KESTRA_EE_LICENSE_ID"));
+        }
 
-        log.info("Kestra started at URL: {}", KESTRA_URL);
-
-        kestraTestDataUtils = new KestraTestDataUtils(
-            KESTRA_URL,
-            USERNAME,
-            PASSWORD,
-            TENANT_ID
-        );
+        return container;
     }
 }

--- a/src/test/java/io/kestra/plugin/AbstractKestraEeContainerTest.java
+++ b/src/test/java/io/kestra/plugin/AbstractKestraEeContainerTest.java
@@ -1,0 +1,18 @@
+package io.kestra.plugin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@Slf4j
+public abstract class AbstractKestraEeContainerTest extends AbstractKestraContainerTest {
+    @Container
+    protected static final GenericContainer<?> KESTRA_EE_CONTAINER = new AbstractKestraEeContainerTest(){}.buildContainer("ghcr.io/kestra-io/kestra-ee:develop", true);
+
+    @Override
+    protected GenericContainer<?> getContainer() {
+        return KESTRA_EE_CONTAINER;
+    }
+}

--- a/src/test/java/io/kestra/plugin/AbstractKestraOssContainerTest.java
+++ b/src/test/java/io/kestra/plugin/AbstractKestraOssContainerTest.java
@@ -1,0 +1,19 @@
+package io.kestra.plugin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@Slf4j
+public abstract class AbstractKestraOssContainerTest extends AbstractKestraContainerTest {
+    @Container
+    protected static final GenericContainer<?> KESTRA_OSS_CONTAINER =
+        new AbstractKestraOssContainerTest(){}.buildContainer("kestra/kestra:develop-no-plugins", false);
+
+    @Override
+    protected GenericContainer<?> getContainer() {
+        return KESTRA_OSS_CONTAINER;
+    }
+}

--- a/src/test/java/io/kestra/plugin/AbstractKestraTaskTest.java
+++ b/src/test/java/io/kestra/plugin/AbstractKestraTaskTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
-public class AbstractKestraTaskTest extends AbstractKestraContainerTest {
+public class AbstractKestraTaskTest extends AbstractKestraOssContainerTest {
 
     @Inject
     protected RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/executions/DeleteTest.java
+++ b/src/test/java/io/kestra/plugin/executions/DeleteTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.tasks.common.FetchOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.executions.Delete;
 import io.kestra.plugin.kestra.executions.Query;
@@ -23,7 +24,7 @@ import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
 @KestraTest
-public class DeleteTest extends AbstractKestraContainerTest {
+public class DeleteTest extends AbstractKestraOssContainerTest {
   @Inject protected RunContextFactory runContextFactory;
 
   protected static final String NAMESPACE = "kestra.tests.executions.delete";

--- a/src/test/java/io/kestra/plugin/executions/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/executions/QueryTest.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.tasks.common.FetchOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.executions.Query;
 import io.kestra.sdk.model.FlowWithSource;
@@ -16,7 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
-public class QueryTest extends AbstractKestraContainerTest {
+public class QueryTest extends AbstractKestraOssContainerTest {
     @Inject
     protected RunContextFactory runContextFactory;
 

--- a/src/test/java/io/kestra/plugin/flows/ExportByIdTest.java
+++ b/src/test/java/io/kestra/plugin/flows/ExportByIdTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.flows.ExportById;
 import io.kestra.sdk.model.FlowWithSource;
@@ -19,7 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
-public class ExportByIdTest extends AbstractKestraContainerTest {
+public class ExportByIdTest extends AbstractKestraOssContainerTest {
 
     @Inject
     protected RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/flows/ExportTest.java
+++ b/src/test/java/io/kestra/plugin/flows/ExportTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.flows.Export;
 import jakarta.inject.Inject;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
-public class ExportTest extends AbstractKestraContainerTest {
+public class ExportTest extends AbstractKestraOssContainerTest {
 
     @Inject
     protected RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/flows/ListTest.java
+++ b/src/test/java/io/kestra/plugin/flows/ListTest.java
@@ -5,16 +5,18 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.flows.List;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
+import static io.kestra.core.models.Label.USERNAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-public class ListTest extends AbstractKestraContainerTest {
+public class ListTest extends AbstractKestraOssContainerTest {
     @Inject
     protected RunContextFactory runContextFactory;
 

--- a/src/test/java/io/kestra/plugin/flows/NamespacesWithFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/flows/NamespacesWithFlowsTest.java
@@ -4,7 +4,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.namespaces.NamespacesWithFlows;
 import jakarta.inject.Inject;
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-public class NamespacesWithFlowsTest extends AbstractKestraContainerTest {
+public class NamespacesWithFlowsTest extends AbstractKestraOssContainerTest {
 
     @Inject
     protected RunContextFactory runContextFactory;
@@ -54,5 +54,9 @@ public class NamespacesWithFlowsTest extends AbstractKestraContainerTest {
             .tenantId(Property.ofValue(TENANT_ID))
             .prefix(Property.ofValue(prefix))
             .build();
+    }
+
+    protected static boolean useEE() {
+        return true;
     }
 }

--- a/src/test/java/io/kestra/plugin/namespaces/ListTest.java
+++ b/src/test/java/io/kestra/plugin/namespaces/ListTest.java
@@ -5,6 +5,8 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.AbstractKestraContainerTest;
+import io.kestra.plugin.AbstractKestraEeContainerTest;
+import io.kestra.plugin.AbstractKestraOssContainerTest;
 import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.kestra.plugin.kestra.namespaces.List;
 import jakarta.annotation.Nullable;
@@ -15,7 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-public class ListTest extends AbstractKestraContainerTest {
+public class ListTest extends AbstractKestraEeContainerTest {
 
     @Inject
     protected RunContextFactory runContextFactory;


### PR DESCRIPTION
closes #55 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
