### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/kestra/AbstractKestraTask.java
+++ b/src/main/java/io/kestra/plugin/kestra/AbstractKestraTask.java
@@ -12,6 +12,7 @@ import io.kestra.sdk.KestraClient;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor
@@ -28,16 +29,19 @@ public abstract class AbstractKestraTask extends Task {
             URL used for calls to the Kestra API. When null, renders `{{ kestra.url }}` from configuration; if still empty, defaults to `http://localhost:8080`. Trailing slashes are stripped before use.
             """
     )
+    @PluginProperty(group = "connection")
     private Property<String> kestraUrl;
 
     @Schema(
         title = "Select API authentication",
         description = "Use either an API token or HTTP Basic (username/password); do not provide both."
     )
+    @PluginProperty(group = "connection")
     private Auth auth;
 
     @Schema(title = "Override target tenant", description = "Tenant identifier applied to API calls; defaults to the current execution tenant.")
     @Setter
+    @PluginProperty(group = "connection")
     protected Property<String> tenantId;
 
     protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
@@ -111,12 +115,15 @@ public abstract class AbstractKestraTask extends Task {
     @Getter
     public static class Auth {
         @Schema(title = "API token for bearer auth")
+        @PluginProperty(group = "connection")
         private Property<String> apiToken;
 
         @Schema(title = "Username for HTTP Basic auth")
+        @PluginProperty(group = "connection")
         private Property<String> username;
 
         @Schema(title = "Password for HTTP Basic auth")
+        @PluginProperty(group = "connection")
         private Property<String> password;
 
         @Schema(
@@ -128,6 +135,7 @@ public abstract class AbstractKestraTask extends Task {
                 The Enterprise edition also provides setting a default configuration at the Namespace of Tenant level by an administrator."""
         )
         @Builder.Default
+        @PluginProperty(group = "advanced")
         private Property<Boolean> auto = Property.ofValue(Boolean.TRUE);
     }
 }

--- a/src/main/java/io/kestra/plugin/kestra/AbstractKestraTrigger.java
+++ b/src/main/java/io/kestra/plugin/kestra/AbstractKestraTrigger.java
@@ -12,6 +12,7 @@ import io.kestra.sdk.KestraClient;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @NoArgsConstructor
@@ -28,16 +29,19 @@ public abstract class AbstractKestraTrigger extends AbstractTrigger {
             URL used for calls to the Kestra API. When null, renders `{{ kestra.url }}` from configuration; if still empty, defaults to http://localhost:8080. Trailing slashes are stripped before use.
             """
     )
+    @PluginProperty(group = "connection")
     private Property<String> kestraUrl;
 
     @Schema(
         title = "Select API authentication",
         description = "Use either an API token or HTTP Basic (username/password); do not provide both."
     )
+    @PluginProperty(group = "connection")
     private Auth auth;
 
     @Schema(title = "Override target tenant", description = "Tenant identifier applied to API calls; defaults to the current execution tenant.")
     @Setter
+    @PluginProperty(group = "connection")
     protected Property<String> tenantId;
 
     protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
@@ -112,12 +116,15 @@ public abstract class AbstractKestraTrigger extends AbstractTrigger {
     @Getter
     public static class Auth {
         @Schema(title = "API token for bearer auth")
+        @PluginProperty(group = "connection")
         private Property<String> apiToken;
 
         @Schema(title = "Username for HTTP Basic auth")
+        @PluginProperty(group = "connection")
         private Property<String> username;
 
         @Schema(title = "Password for HTTP Basic auth")
+        @PluginProperty(group = "connection")
         private Property<String> password;
 
         @Schema(
@@ -129,6 +136,7 @@ public abstract class AbstractKestraTrigger extends AbstractTrigger {
                 The Enterprise edition also provides setting a default configuration at the Namespace of Tenant level by an administrator."""
         )
         @Builder.Default
+        @PluginProperty(group = "advanced")
         private Property<Boolean> auto = Property.ofValue(Boolean.TRUE);
     }
 }

--- a/src/main/java/io/kestra/plugin/kestra/ee/assets/Delete.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/assets/Delete.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @Getter
@@ -43,6 +44,7 @@ public class Delete extends AbstractKestraTask implements RunnableTask<VoidOutpu
     @Schema(
         title = "Asset ID to delete"
     )
+    @PluginProperty(group = "main")
     private Property<String> assetId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/ee/assets/FreshnessTrigger.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/assets/FreshnessTrigger.java
@@ -35,6 +35,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwBiConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -146,12 +147,14 @@ public class FreshnessTrigger extends AbstractKestraTrigger implements PollingTr
         title = "Maximum allowed time since last update (e.g., PT24H, P1D)"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Duration> maxStaleness;
 
     @Schema(
         title = "How often the trigger should check for stale assets. Default is 1 hour."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private final Duration interval = Duration.ofHours(1);
 
     private Property<List<FieldQuery>> metadataQuery;

--- a/src/main/java/io/kestra/plugin/kestra/ee/assets/List.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/assets/List.java
@@ -28,6 +28,7 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwBiConsumer;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @Getter
@@ -75,6 +76,7 @@ public class List extends AbstractKestraTask implements RunnableTask<List.Output
         title = "Page number",
         description = "If omitted, all pages are iterated. Set to 1+ to fetch a single page with `size` items."
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> page;
 
     @Nullable
@@ -83,12 +85,14 @@ public class List extends AbstractKestraTask implements RunnableTask<List.Output
         title = "Page size",
         description = "Number of assets per page; defaults to 100."
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> size = Property.ofValue(100);
 
     @Nullable
     @Schema(
         title = "Namespace filter"
     )
+    @PluginProperty(group = "connection")
     private Property<String> namespace;
 
     @Nullable
@@ -108,6 +112,7 @@ public class List extends AbstractKestraTask implements RunnableTask<List.Output
         description = "Defines how results are returned (e.g., `FETCH` for direct output, `STORE` to persist as a file)."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.STORE);
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/ee/assets/PurgeAssets.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/assets/PurgeAssets.java
@@ -28,6 +28,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwBiConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @Getter
@@ -84,18 +85,21 @@ public class PurgeAssets extends AbstractKestraTask implements RunnableTask<Purg
         title = "Filter assets by namespace",
         description = "Exact match or prefix with .*"
     )
+    @PluginProperty(group = "connection")
     private Property<String> namespace;
 
     @Nullable
     @Schema(
         title = "Filter assets by id"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> assetId;
 
     @Nullable
     @Schema(
         title = "Filter by asset types"
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> assetType;
 
     @Nullable
@@ -108,6 +112,7 @@ public class PurgeAssets extends AbstractKestraTask implements RunnableTask<Purg
     @Schema(
         title = "Purge assets created or updated before this date (ISO 8601)"
     )
+    @PluginProperty(group = "main")
     private Property<Instant> endDate;
 
     @NotNull
@@ -115,6 +120,7 @@ public class PurgeAssets extends AbstractKestraTask implements RunnableTask<Purg
         title = "Whether to purge assets matching the filters"
     )
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> purgeAssets = Property.ofValue(true);
 
     @NotNull
@@ -122,6 +128,7 @@ public class PurgeAssets extends AbstractKestraTask implements RunnableTask<Purg
         title = "Whether to purge asset usage events (execution view) matching the filters"
     )
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> purgeAssetUsages = Property.ofValue(true);
 
     @NotNull
@@ -129,6 +136,7 @@ public class PurgeAssets extends AbstractKestraTask implements RunnableTask<Purg
         title = "Whether to purge asset lineage events (for asset exporters) matching the filters"
     )
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> purgeAssetLineages = Property.ofValue(true);
 
     @Override
@@ -301,16 +309,19 @@ public class PurgeAssets extends AbstractKestraTask implements RunnableTask<Purg
         @Schema(
             title = "Number of assets purged"
         )
+        @PluginProperty(group = "advanced")
         private Integer purgedAssetsCount;
 
         @Schema(
             title = "Number of asset usages purged"
         )
+        @PluginProperty(group = "advanced")
         private Integer purgedAssetUsagesCount;
 
         @Schema(
             title = "Number of asset lineages purged"
         )
+        @PluginProperty(group = "advanced")
         private Integer purgedAssetLineagesCount;
     }
 }

--- a/src/main/java/io/kestra/plugin/kestra/ee/assets/Set.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/assets/Set.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @Getter
@@ -55,33 +56,39 @@ public class Set extends AbstractKestraTask implements RunnableTask<VoidOutput> 
     @Schema(
         title = "Namespace for the asset"
     )
+    @PluginProperty(group = "connection")
     private Property<String> namespace;
 
     @NotNull
     @Schema(
         title = "Asset ID"
     )
+    @PluginProperty(group = "main")
     private Property<String> assetId;
 
     @NotNull
     @Schema(
         title = "Asset type"
     )
+    @PluginProperty(group = "main")
     private Property<String> assetType;
 
     @Schema(
         title = "Asset display name"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> displayName;
 
     @Schema(
         title = "Asset description"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> assetDescription;
 
     @Schema(
         title = "Asset metadata"
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> metadata;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/ee/tests/RunTest.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/tests/RunTest.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -72,18 +73,22 @@ import lombok.experimental.SuperBuilder;
 public class RunTest extends AbstractKestraTask implements RunnableTask<RunTest.Output> {
     @Schema(title = "Namespace containing the test suite")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> namespace;
 
     @Schema(title = "Test suite id")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> testId;
 
     @Schema(title = "Test case ids to run", description = "Leave empty to run every test case in the suite.")
     @Nullable
+    @PluginProperty(group = "advanced")
     private Property<List<String>> testCases;
 
     @Schema(title = "Fail task on test failures", description = "Defaults to false. When true, FAILED test cases set the task state to FAILED instead of WARNING.")
     @Builder.Default
+    @PluginProperty(group = "reliability")
     private Property<Boolean> failOnTestFailure = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/ee/tests/RunTests.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/tests/RunTests.java
@@ -21,6 +21,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.plugin.kestra.ee.tests.RunTest.logTestCase;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -52,18 +53,22 @@ import static io.kestra.plugin.kestra.ee.tests.RunTest.logTestCase;
 public class RunTests extends AbstractKestraTask implements RunnableTask<RunTests.Output> {
     @Schema(title = "Namespace filter", description = "If null, runs against the current tenant. Set to limit to a namespace; includeChildNamespaces controls recursion.")
     @Nullable
+    @PluginProperty(group = "source")
     private Property<String> namespace;
 
     @Schema(title = "Include child namespaces", description = "Defaults to true. Applies when namespace is set.")
     @Builder.Default
+    @PluginProperty(group = "source")
     private Property<Boolean> includeChildNamespaces = Property.ofValue(true);
 
     @Schema(title = "Flow id filter", description = "Optional flow identifier to scope test suites.")
     @Nullable
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Schema(title = "Fail task on test failures", description = "Defaults to false. When true, FAILED test suites set the task state to FAILED instead of WARNING.")
     @Builder.Default
+    @PluginProperty(group = "reliability")
     private Property<Boolean> failOnTestFailure = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/executions/Count.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Count.java
@@ -67,27 +67,32 @@ import lombok.experimental.SuperBuilder;
 )
 public class Count extends AbstractKestraTask implements RunnableTask<Count.Output> {
     @Schema(title = "Namespaces filter", description = "Limit the search to these namespaces; leave empty for all.")
+    @PluginProperty(group = "source")
     private Property<List<String>> namespaces;
 
     @Schema(title = "Flow id filter")
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Schema(title = "Execution states", description = "Only count executions currently in these states.")
+    @PluginProperty(group = "advanced")
     private Property<List<StateType>> states;
 
     @Schema(
         title = "Start date",
         description = "Counts executions starting from this date."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> startDate;
 
     @Schema(
         title = "End date",
         description = "Counts executions up to this date."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> endDate;
 
-    @PluginProperty(dynamic = true) // we cannot use `Property` as we render it multiple time with different variables, which is an issue for the property cache
+    @PluginProperty(group = "advanced", dynamic = true) // we cannot use `Property` as we render it multiple time with different variables, which is an issue for the property cache
     @Schema(
         title = "Expression evaluated on count",
         description = "Rendered with variable `count`; if the expression does not return true, the exposed count is set to 0. Example: `{{ gte count 5 }}`."

--- a/src/main/java/io/kestra/plugin/kestra/executions/Delete.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Delete.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -57,18 +58,22 @@ public class Delete extends AbstractKestraTask implements RunnableTask<VoidOutpu
         description = "ID of the target execution; deleting the current execution is not allowed."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> executionId;
 
     @Schema(title = "Delete execution logs", description = "Defaults to true.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> deleteLogs = Property.ofValue(true);
 
     @Schema(title = "Delete execution metrics", description = "Defaults to true.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> deleteMetrics = Property.ofValue(true);
 
     @Schema(title = "Delete execution files", description = "Defaults to true; removes files stored in internal storage.")
     @Builder.Default
+    @PluginProperty(group = "destination")
     private Property<Boolean> deleteStorage = Property.ofValue(true);
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/executions/Kill.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Kill.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -79,6 +80,7 @@ public class Kill extends AbstractKestraTask implements RunnableTask<VoidOutput>
         description = "ID of the execution to kill; use `{{ execution.id }}` for the current one."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> executionId;
 
     @Schema(
@@ -86,6 +88,7 @@ public class Kill extends AbstractKestraTask implements RunnableTask<VoidOutput>
         description = "Defaults to true. When true, also kills subflow executions."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> propagateKill = Property.ofValue(true);
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/executions/Query.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Query.java
@@ -32,6 +32,7 @@ import jakarta.annotation.Nullable;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -88,52 +89,64 @@ import reactor.core.publisher.Flux;
 public class Query extends AbstractKestraTask implements RunnableTask<FetchOutput> {
     @Nullable
     @Schema(title = "Page number", description = "When null, iterates through all pages. Combine with size to limit requests.")
+    @PluginProperty(group = "advanced")
     private Property<Integer> page;
 
     @Nullable
     @Builder.Default
     @Schema(title = "Page size", description = "Defaults to 10.")
+    @PluginProperty(group = "advanced")
     private Property<Integer> size = Property.ofValue(10);
 
     @Nullable
     @Builder.Default
     @Schema(title = "Fetch strategy", description = "Defaults to STORE (writes to internal storage and returns URI). FETCH returns rows in output; FETCH_ONE returns the first execution.")
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.STORE);
 
     @Nullable
     @Schema(title = "Flow scope filter", description = "USER for user-created executions, SYSTEM for system executions; defaults to both.")
+    @PluginProperty(group = "advanced")
     private Property<List<FlowScope>> flowScopes;
 
     @Nullable
     @Schema(title = "Namespace filter")
+    @PluginProperty(group = "source")
     private Property<String> namespace;
 
     @Nullable
     @Schema(title = "Flow id filter")
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Nullable
     @Schema(title = "Start date (inclusive)")
+    @PluginProperty(group = "advanced")
     private Property<ZonedDateTime> startDate;
 
     @Nullable
     @Schema(title = "End date (inclusive)")
+    @PluginProperty(group = "advanced")
     private Property<ZonedDateTime> endDate;
 
     @Nullable
     @Schema(title = "Relative time range", description = "Duration back from now. Cannot be used with both startDate and endDate.")
+    @PluginProperty(group = "advanced")
     private Property<Duration> timeRange;
 
     @Nullable
     @Schema(title = "Execution states")
+    @PluginProperty(group = "advanced")
     private Property<List<StateType>> states;
 
     @Nullable
     @Schema(title = "Labels filter", description = "Matches executions containing the provided key/value pairs.")
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> labels;
 
     @Nullable
     @Schema(title = "Downstream of execution ID")
+    @PluginProperty(group = "advanced")
     private Property<String> triggerExecutionId;
 
     @Nullable

--- a/src/main/java/io/kestra/plugin/kestra/executions/Resume.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Resume.java
@@ -14,6 +14,7 @@ import io.kestra.plugin.kestra.AbstractKestraTask;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -72,9 +73,11 @@ public class Resume extends AbstractKestraTask implements RunnableTask<VoidOutpu
         title = "Execution ID to resume",
         description = "Defaults to the current execution when not provided."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> executionId;
 
     @Schema(title = "Inputs to send with resume")
+    @PluginProperty(group = "source")
     private Property<Map<String, Object>> inputs;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/flows/Export.java
+++ b/src/main/java/io/kestra/plugin/kestra/flows/Export.java
@@ -21,6 +21,7 @@ import io.kestra.sdk.model.QueryFilterOp;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -55,9 +56,11 @@ import lombok.experimental.SuperBuilder;
 public class Export extends AbstractKestraTask implements RunnableTask<Export.Output> {
 
     @Schema(title = "Namespace prefix", description = "Limit export to flows whose namespace matches this prefix.")
+    @PluginProperty(group = "source")
     public Property<String> namespace;
 
     @Schema(title = "Label filters", description = "List of `key:value` labels all flows must contain.")
+    @PluginProperty(group = "advanced")
     public Property<List<String>> labels;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/flows/ExportById.java
+++ b/src/main/java/io/kestra/plugin/kestra/flows/ExportById.java
@@ -17,6 +17,7 @@ import io.kestra.sdk.model.IdWithNamespace;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -77,6 +78,7 @@ import lombok.experimental.SuperBuilder;
 public class ExportById extends AbstractKestraTask implements RunnableTask<ExportById.Output> {
 
     @Schema(title = "Flows to export", description = "List of id/namespace pairs.")
+    @PluginProperty(group = "advanced")
     public Property<List<IdWithNamespace>> flows;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/flows/List.java
+++ b/src/main/java/io/kestra/plugin/kestra/flows/List.java
@@ -12,6 +12,7 @@ import io.kestra.sdk.model.Flow;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,6 +64,7 @@ import lombok.experimental.SuperBuilder;
 public class List extends AbstractKestraTask implements RunnableTask<List.Output> {
 
     @Schema(title = "Namespace to list", description = "Defaults to the current flow namespace when null.")
+    @PluginProperty(group = "source")
     private Property<String> namespace;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/logs/Fetch.java
+++ b/src/main/java/io/kestra/plugin/kestra/logs/Fetch.java
@@ -24,6 +24,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,9 +72,11 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
 )
 public class Fetch extends AbstractKestraTask implements RunnableTask<Fetch.Output> {
     @Schema(title = "Execution namespace", description = "Used when targeting another execution; defaults to the current flow namespace.")
+    @PluginProperty(group = "source")
     private Property<String> namespace;
 
     @Schema(title = "Execution flow id", description = "Required when fetching a different flow's execution without a fully qualified ID.")
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Schema(
@@ -81,13 +84,16 @@ public class Fetch extends AbstractKestraTask implements RunnableTask<Fetch.Outp
         description = """
             Defaults to the current execution ID. Provide namespace and flowId when referencing an execution from another flow."""
     )
+    @PluginProperty(group = "advanced")
     private Property<String> executionId;
 
     @Schema(title = "Task ids filter", description = "Limit logs to these task ids; empty list fetches all tasks.")
+    @PluginProperty(group = "advanced")
     private Property<List<String>> tasksId;
 
     @Schema(title = "Minimum log level", description = "Defaults to INFO; lower levels are excluded.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Level> level = Property.ofValue(Level.INFO);
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/kestra/plugin/kestra/namespaces/List.java
+++ b/src/main/java/io/kestra/plugin/kestra/namespaces/List.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -85,19 +86,23 @@ import lombok.experimental.SuperBuilder;
 )
 public class List extends AbstractKestraTask implements RunnableTask<List.Output> {
     @Schema(title = "Namespace prefix", description = "Defaults to empty string to return all namespaces.")
+    @PluginProperty(group = "source")
     private Property<String> prefix;
 
     @Nullable
     @Schema(title = "Page number", description = "When null, fetches every page. Set with size to limit requests.")
+    @PluginProperty(group = "advanced")
     private Property<Integer> page;
 
     @Nullable
     @Builder.Default
     @Schema(title = "Page size", description = "Defaults to 10.")
+    @PluginProperty(group = "advanced")
     private Property<Integer> size = Property.ofValue(10);
 
     @Builder.Default
     @Schema(title = "Existing namespaces only", description = "Defaults to false. When true, returns namespaces backed by stored definition, excluding transient ones.")
+    @PluginProperty(group = "advanced")
     private Property<Boolean> existingOnly = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/namespaces/NamespacesWithFlows.java
+++ b/src/main/java/io/kestra/plugin/kestra/namespaces/NamespacesWithFlows.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -64,6 +65,7 @@ public class NamespacesWithFlows extends AbstractKestraTask implements RunnableT
 
     @Schema(title = "Namespace prefix", description = "Defaults to empty string to include all namespaces.")
     @Nullable
+    @PluginProperty(group = "source")
     private Property<String> prefix;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/triggers/ScheduleMonitor.java
+++ b/src/main/java/io/kestra/plugin/kestra/triggers/ScheduleMonitor.java
@@ -23,6 +23,7 @@ import io.kestra.sdk.model.Trigger;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -67,13 +68,16 @@ public class ScheduleMonitor extends AbstractKestraTrigger implements TriggerOut
     private final Duration interval = Duration.ofSeconds(60);
 
     @Schema(title = "Namespace filter", description = "Prefix match; null scans all namespaces.")
+    @PluginProperty(group = "connection")
     private Property<String> namespace;
 
     @Schema(title = "Flow filter")
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Schema(title = "Include disabled schedules", description = "Defaults to false.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeDisabled = Property.ofValue(false);
 
     @Schema(
@@ -81,18 +85,21 @@ public class ScheduleMonitor extends AbstractKestraTrigger implements TriggerOut
         description = "Defaults to PT1M. If now is after next execution plus this delay, trigger is flagged."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Duration> allowedDelay = Property.ofValue(Duration.ofMinutes(1));
 
     @Schema(
         title = "Max execution duration",
         description = "When set, a RUNNING execution longer than this is flagged."
     )
+    @PluginProperty(group = "execution")
     private Property<Duration> maxExecutionDuration;
 
     @Schema(
         title = "Max idle interval between runs",
         description = "Flags schedules with no execution within this period."
     )
+    @PluginProperty(group = "execution")
     private Property<Duration> maxExecutionInterval;
 
     @Override

--- a/src/main/java/io/kestra/plugin/kestra/triggers/Toggle.java
+++ b/src/main/java/io/kestra/plugin/kestra/triggers/Toggle.java
@@ -17,6 +17,7 @@ import io.kestra.sdk.model.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -72,16 +73,20 @@ public class Toggle extends AbstractKestraTask implements RunnableTask<VoidOutpu
         title = "Flow id filter",
         description = "Defaults to current flow id when null."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Schema(title = "Namespace filter", description = "Defaults to current flow namespace.")
+    @PluginProperty(group = "source")
     private Property<String> namespace;
 
     @Schema(title = "Trigger id to toggle", description = "Optional; when null and multiple triggers match, all are toggled.")
+    @PluginProperty(group = "advanced")
     private Property<String> trigger;
 
     @Schema(title = "Set trigger enabled", description = "Defaults to false.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> enabled = Property.ofValue(false);
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712