### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/kestra/ee/assets/FreshnessTrigger.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/assets/FreshnessTrigger.java
@@ -61,7 +61,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: send_alert
-                    type: io.kestra.plugin.notifications.slack.SlackIncoming
+                    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
                     url: "{{ secret('SLACK_WEBHOOK') }}"
                     payload: |
                       {
@@ -126,7 +126,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                  - id: alert_stale_regional_assets
-                   type: io.kestra.plugin.notifications.slack.SlackIncoming
+                   type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
                    url: "{{ secret('OPS_WEBHOOK') }}"
                    payload: |
                      {

--- a/src/test/java/io/kestra/plugin/kestra/logs/FetchTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/logs/FetchTest.java
@@ -37,15 +37,15 @@ public class FetchTest extends AbstractKestraOssContainerTest {
 
             tasks:
               - id: log-1
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Log number 1"
                 level: INFO
               - id: log-2
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Log number 2"
                 level: INFO
               - id: log-3
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Log number 3"
                 level: INFO
             """.formatted(NAMESPACE);
@@ -86,11 +86,11 @@ public class FetchTest extends AbstractKestraOssContainerTest {
 
             tasks:
               - id: specific-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Target Log"
                 level: INFO
               - id: other-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Ignored Log"
                 level: INFO
             """.formatted(NAMESPACE);
@@ -132,15 +132,15 @@ public class FetchTest extends AbstractKestraOssContainerTest {
 
             tasks:
               - id: log-1
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Log 1"
                 level: INFO
               - id: log-2
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Log 2"
                 level: INFO
               - id: log-3
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: "Log 3"
                 level: INFO
             """.formatted(NAMESPACE);

--- a/src/test/resources/flows/valids/get-log-executionid.yaml
+++ b/src/test/resources/flows/valids/get-log-executionid.yaml
@@ -3,15 +3,15 @@ namespace: io.kestra.tests
 
 tasks:
   - id: log-1
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Log 1"
     level: INFO
   - id: log-2
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Log 2"
     level: INFO
   - id: log-3
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Log 3"
     level: INFO
 

--- a/src/test/resources/flows/valids/get-log-taskid.yaml
+++ b/src/test/resources/flows/valids/get-log-taskid.yaml
@@ -3,11 +3,11 @@ namespace: io.kestra.tests
 
 tasks:
   - id: specific-task
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Target Log"
     level: INFO
   - id: other-task
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Ignored Log"
     level: INFO
 

--- a/src/test/resources/flows/valids/get-log.yaml
+++ b/src/test/resources/flows/valids/get-log.yaml
@@ -3,15 +3,15 @@ namespace: io.kestra.tests
 
 tasks:
   - id: log-1
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Log number 1"
     level: INFO
   - id: log-2
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Log number 2"
     level: INFO
   - id: log-3
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "Log number 3"
     level: INFO
 

--- a/src/test/resources/flows/valids/security-check-ignore-namespace.yaml
+++ b/src/test/resources/flows/valids/security-check-ignore-namespace.yaml
@@ -3,7 +3,7 @@ namespace: io.kestra.tests
 
 tasks:
   - id: log-1
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "I am safe"
     level: INFO
 


### PR DESCRIPTION
Updates the deprecated task identifiers in the examples to their current names