### PR TITLE
feat(locks): asset Acquire/Release tasks + SDK 1.0.12 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // kestra API client
-    implementation "io.kestra:kestra-api-client:1.3.2"
+    implementation "io.kestra:kestra-api-client:2.0.0-SNAPSHOT"
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/io/kestra/plugin/kestra/ee/iam/groups/List.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/iam/groups/List.java
@@ -96,13 +96,13 @@ public class List extends AbstractKestraTask implements RunnableTask<List.Output
 
         java.util.List<ApiGroupSummary> fetched;
         if (rPage != null) {
-            fetched = kestraClient.groups().searchGroups(rTenant, rPage, rSize, null, null, null).getResults();
+            fetched = kestraClient.groups().searchGroups(rTenant, rPage, rSize, null, null).getResults();
         } else {
             fetched = new ArrayList<>();
             int currentPage = 1;
             long total;
             do {
-                PagedResultsApiGroupSummary results = kestraClient.groups().searchGroups(rTenant, currentPage, rSize, null, null, null);
+                PagedResultsApiGroupSummary results = kestraClient.groups().searchGroups(rTenant, currentPage, rSize, null, null);
                 fetched.addAll(results.getResults());
                 total = results.getTotal();
             } while ((long) currentPage++ * rSize < total);

--- a/src/main/java/io/kestra/plugin/kestra/ee/iam/groups/Set.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/iam/groups/Set.java
@@ -72,7 +72,7 @@ public class Set extends AbstractKestraTask implements RunnableTask<Set.Output> 
         var rDescription = runContext.render(groupDescription).as(String.class).orElse(null);
 
         var existing = kestraClient.groups().searchGroups(
-            rTenant, 1, 100, null, null,
+            rTenant, 1, 100, null,
             List.of(new QueryFilter().field(QueryFilterField.NAME).operation(QueryFilterOp.EQUALS).value(rName))
         ).getResults();
 

--- a/src/main/java/io/kestra/plugin/kestra/ee/iam/roles/List.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/iam/roles/List.java
@@ -96,13 +96,13 @@ public class List extends AbstractKestraTask implements RunnableTask<List.Output
 
         java.util.List<ApiRoleSummary> fetched;
         if (rPage != null) {
-            fetched = kestraClient.roles().searchRoles(rTenant, rPage, rSize, null, null, null).getResults();
+            fetched = kestraClient.roles().searchRoles(rTenant, rPage, rSize, null, null).getResults();
         } else {
             fetched = new ArrayList<>();
             int currentPage = 1;
             long total;
             do {
-                PagedResultsApiRoleSummary results = kestraClient.roles().searchRoles(rTenant, currentPage, rSize, null, null, null);
+                PagedResultsApiRoleSummary results = kestraClient.roles().searchRoles(rTenant, currentPage, rSize, null, null);
                 fetched.addAll(results.getResults());
                 total = results.getTotal();
             } while ((long) currentPage++ * rSize < total);

--- a/src/main/java/io/kestra/plugin/kestra/ee/iam/roles/Set.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/iam/roles/Set.java
@@ -98,7 +98,7 @@ public class Set extends AbstractKestraTask implements RunnableTask<Set.Output> 
         var rPermissions = JacksonMapper.ofJson().convertValue(rPermissionsMap, IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions.class);
 
         var existing = kestraClient.roles().searchRoles(
-            rTenant, 1, 100, null, null,
+            rTenant, 1, 100, null,
             List.of(new QueryFilter().field(QueryFilterField.NAME).operation(QueryFilterOp.EQUALS).value(rName))
         ).getResults();
 

--- a/src/main/java/io/kestra/plugin/kestra/ee/locks/Acquire.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/locks/Acquire.java
@@ -1,0 +1,114 @@
+package io.kestra.plugin.kestra.ee.locks;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Output;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.kestra.AbstractKestraTask;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.model.AssetsControllerApiAssetLock;
+import io.kestra.sdk.model.AssetsControllerAssetLockRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Acquire a lock on an asset for the duration of the execution.",
+    description = """
+        Acquires an EXECUTION-owned lock on the asset on behalf of the current execution, so concurrent \
+        flow writes to the asset are rejected while it is held. The lock is released by the `Release` task, \
+        or automatically when its `ttl` expires. The calling credential must hold the `LOCK` permission \
+        on the `ASSET` resource (typically a dedicated service account); other principals are rejected with 403."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Lock an asset while a flow writes to it, then release it.",
+            full = true,
+            code = """
+                id: lock_asset
+                namespace: company.team
+
+                tasks:
+                  - id: acquire
+                    type: io.kestra.plugin.kestra.ee.locks.Acquire
+                    assetId: customers_by_country
+                    ttl: PT1H
+                  - id: write
+                    type: io.kestra.plugin.core.log.Log
+                    message: writing to the locked asset
+                  - id: release
+                    type: io.kestra.plugin.kestra.ee.locks.Release
+                    assetId: customers_by_country
+                """
+        )
+    }
+)
+public class Acquire extends AbstractKestraTask implements RunnableTask<Acquire.AcquireOutput> {
+    @NotNull
+    @Schema(title = "The ID of the asset to lock.")
+    @PluginProperty(group = "main")
+    private Property<String> assetId;
+
+    @Schema(
+        title = "How long the lock is held before it expires.",
+        description = "An ISO-8601 duration (e.g. `PT1H`). When unset, the server default TTL applies."
+    )
+    @PluginProperty(group = "main")
+    private Property<Duration> ttl;
+
+    @Override
+    public AcquireOutput run(RunContext runContext) throws Exception {
+        KestraClient kestraClient = kestraClient(runContext);
+
+        String tenant = runContext.render(tenantId).as(String.class).orElse(runContext.flowInfo().tenantId());
+        String rAssetId = runContext.render(assetId).as(String.class).orElseThrow();
+
+        AssetsControllerAssetLockRequest request = new AssetsControllerAssetLockRequest()
+            .executionId(runContext.render("{{ execution.id }}"))
+            .flowId(runContext.flowInfo().id())
+            .flowNamespace(runContext.flowInfo().namespace())
+            .taskRunId(runContext.render("{{ taskrun.id }}"));
+        runContext.render(ttl).as(Duration.class).ifPresent(t -> request.ttl(t.toString()));
+
+        AssetsControllerApiAssetLock lock = kestraClient.assets().lockAsset(rAssetId, tenant, request);
+
+        OffsetDateTime lockedUntil = lock.getLockedUntil();
+        return AcquireOutput.builder()
+            .lockedUntil(lockedUntil != null ? lockedUntil.toInstant() : null)
+            .ownerType(lock.getOwnerType())
+            .executionId(lock.getExecutionId())
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class AcquireOutput implements Output {
+        @Schema(title = "The instant at which the lock expires.")
+        private final Instant lockedUntil;
+
+        @Schema(title = "The lock owner type (always EXECUTION for a task-acquired lock).")
+        private final String ownerType;
+
+        @Schema(title = "The id of the execution holding the lock.")
+        private final String executionId;
+    }
+}

--- a/src/main/java/io/kestra/plugin/kestra/ee/locks/Release.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/locks/Release.java
@@ -1,0 +1,69 @@
+package io.kestra.plugin.kestra.ee.locks;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.kestra.AbstractKestraTask;
+import io.kestra.sdk.KestraClient;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Release the lock held on an asset by the current execution.",
+    description = """
+        Releases the EXECUTION-owned lock acquired by `Acquire` for the current execution. The release is \
+        owner-checked: it only removes a lock still held by this execution and is a no-op otherwise (e.g. if \
+        the lock already expired or was taken over), so it is safe to run unconditionally. Requires the \
+        `UNLOCK` permission on the `ASSET` resource."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Release a lock acquired earlier in the flow.",
+            full = true,
+            code = """
+                id: release_asset_lock
+                namespace: company.team
+
+                tasks:
+                  - id: release
+                    type: io.kestra.plugin.kestra.ee.locks.Release
+                    assetId: customers_by_country
+                """
+        )
+    }
+)
+public class Release extends AbstractKestraTask implements RunnableTask<VoidOutput> {
+    @NotNull
+    @Schema(title = "The ID of the asset to unlock.")
+    @PluginProperty(group = "main")
+    private Property<String> assetId;
+
+    @Override
+    public VoidOutput run(RunContext runContext) throws Exception {
+        KestraClient kestraClient = kestraClient(runContext);
+
+        String tenant = runContext.render(tenantId).as(String.class).orElse(runContext.flowInfo().tenantId());
+        String rAssetId = runContext.render(assetId).as(String.class).orElseThrow();
+
+        // owner-checked: passing the current execution id releases only this execution's lock.
+        kestraClient.assets().unlockAsset(rAssetId, tenant, runContext.render("{{ execution.id }}"));
+
+        return null;
+    }
+}

--- a/src/main/java/io/kestra/plugin/kestra/ee/locks/package-info.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/locks/package-info.java
@@ -1,0 +1,6 @@
+@PluginSubGroup(
+    title = "Kestra Asset Locks", categories = { PluginSubGroup.PluginCategory.CORE }
+)
+package io.kestra.plugin.kestra.ee.locks;
+
+import io.kestra.core.models.annotations.PluginSubGroup;

--- a/src/test/java/io/kestra/plugin/kestra/ee/locks/AcquireTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/ee/locks/AcquireTest.java
@@ -1,0 +1,75 @@
+package io.kestra.plugin.kestra.ee.locks;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.kestra.AbstractKestraEeContainerTest;
+import io.kestra.plugin.kestra.AbstractKestraTask;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.AssetsControllerAssetLockRequest;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@KestraTest
+class AcquireTest extends AbstractKestraEeContainerTest {
+
+    @Inject
+    TestRunContextFactory runContextFactory;
+
+    private Acquire.AcquireOutput acquire(String assetId) throws Exception {
+        Acquire acquire = Acquire.builder()
+            .id(Acquire.class.getSimpleName())
+            .type(Acquire.class.getName())
+            .kestraUrl(Property.ofValue(KESTRA_URL))
+            .auth(
+                AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue(USERNAME))
+                    .password(Property.ofValue(PASSWORD))
+                    .build()
+            )
+            .tenantId(Property.ofValue(TENANT_ID))
+            .assetId(Property.ofExpression("{{ inputs.assetId }}"))
+            .ttl(Property.ofValue(Duration.ofMinutes(5)))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(
+            this.runContextFactory, acquire, Map.of("assetId", assetId)
+        );
+        return acquire.run(runContext);
+    }
+
+    @Test
+    void shouldAcquireExecutionOwnedLock() throws Exception {
+        String assetId = IdUtils.create().toLowerCase();
+        kestraTestDataUtils.createAsset(assetId, "TABLE");
+
+        Acquire.AcquireOutput output = acquire(assetId);
+
+        assertThat(output.getOwnerType()).isEqualTo("EXECUTION");
+        assertThat(output.getExecutionId()).isNotBlank();
+        assertThat(output.getLockedUntil()).isAfter(Instant.now());
+    }
+
+    @Test
+    void shouldRejectLockingAnAlreadyLockedAsset() throws Exception {
+        String assetId = IdUtils.create().toLowerCase();
+        kestraTestDataUtils.createAsset(assetId, "TABLE");
+        acquire(assetId);
+
+        assertThatThrownBy(() -> kestraTestDataUtils.getKestraClient().assets()
+            .lockAsset(assetId, TENANT_ID, new AssetsControllerAssetLockRequest().ttl("PT5M")))
+            .isInstanceOf(ApiException.class);
+    }
+}

--- a/src/test/java/io/kestra/plugin/kestra/ee/locks/ReleaseTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/ee/locks/ReleaseTest.java
@@ -1,0 +1,62 @@
+package io.kestra.plugin.kestra.ee.locks;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.kestra.AbstractKestraEeContainerTest;
+import io.kestra.plugin.kestra.AbstractKestraTask;
+import io.kestra.sdk.model.AssetsControllerApiAssetLock;
+import io.kestra.sdk.model.AssetsControllerAssetLockRequest;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@KestraTest
+class ReleaseTest extends AbstractKestraEeContainerTest {
+
+    @Inject
+    TestRunContextFactory runContextFactory;
+
+    @Test
+    void shouldReleaseOwnExecutionLock() throws Exception {
+        String assetId = IdUtils.create().toLowerCase();
+        kestraTestDataUtils.createAsset(assetId, "TABLE");
+
+        Release release = Release.builder()
+            .id(Release.class.getSimpleName())
+            .type(Release.class.getName())
+            .kestraUrl(Property.ofValue(KESTRA_URL))
+            .auth(
+                AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue(USERNAME))
+                    .password(Property.ofValue(PASSWORD))
+                    .build()
+            )
+            .tenantId(Property.ofValue(TENANT_ID))
+            .assetId(Property.ofExpression("{{ inputs.assetId }}"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(
+            this.runContextFactory, release, Map.of("assetId", assetId)
+        );
+        String executionId = runContext.render("{{ execution.id }}");
+
+        kestraTestDataUtils.getKestraClient().assets().lockAsset(assetId, TENANT_ID,
+            new AssetsControllerAssetLockRequest().ttl("PT5M").executionId(executionId));
+
+        assertThatCode(() -> release.run(runContext)).doesNotThrowAnyException();
+
+        AssetsControllerApiAssetLock relock = kestraTestDataUtils.getKestraClient().assets()
+            .lockAsset(assetId, TENANT_ID, new AssetsControllerAssetLockRequest().ttl("PT5M"));
+        assertThat(relock).isNotNull();
+    }
+}


### PR DESCRIPTION
- Add io.kestra.plugin.kestra.ee.locks.{Acquire, Release}: acquire / owner-release an
  EXECUTION-owned lock on an asset over the assets REST API (lockAsset/unlockAsset). Acquire
  passes the current execution context (executionId + flow info) + ttl; Release is owner-checked.
  Requires the IMPERSONATE permission on the ASSET resource.
- Upgrade to kestra-api-client:1.0.12 and adapt all existing tasks to develop's restructured
  client API (search args reordered tenant-first; Execution -> ApiExecution/ApiLightExecution;
  trigger/log model restructure; namespace `q` -> QUERY filter; Toggle count -> getTotalItems).
- 2 commits: build(deps) SDK upgrade + task modernization; feat(locks) the lock tasks.
- Depends on the SDK 1.0.12 release (companion kestra-io/client-sdk PR) — CI stays red until
  1.0.12 is published to Maven Central.
