### PR TITLE
fix(executions): use LABELS query filter field for labels search

### DIFF
--- a/src/main/java/io/kestra/plugin/kestra/executions/Query.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Query.java
@@ -269,9 +269,9 @@ public class Query extends AbstractKestraTask implements RunnableTask<FetchOutpu
             {
                 filters.add(
                     new QueryFilter()
-                        .field(QueryFilterField.STATE)
+                        .field(QueryFilterField.LABELS)
                         .operation(QueryFilterOp.EQUALS)
-                        .value(key + ":" + value)
+                        .value(Map.of(key, value))
                 );
             });
         }

--- a/src/test/java/io/kestra/plugin/kestra/executions/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/executions/QueryTest.java
@@ -1,5 +1,8 @@
 package io.kestra.plugin.kestra.executions;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -50,5 +53,44 @@ public class QueryTest extends AbstractKestraOssContainerTest {
         assertThat(output, is(notNullValue()));
         assertThat(output.getRows(), is(notNullValue()));
         assertThat(output.getRows().size(), is(greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    public void shouldSearchExecutionsByLabel() throws Exception {
+        RunContext runContext = runContextFactory.of();
+
+        FlowWithSource flow = kestraTestDataUtils.createRandomizedFlow(NAMESPACE);
+        kestraTestDataUtils.getKestraClient().executions().createExecution(
+            TENANT_ID, flow.getNamespace(), flow.getId(), List.of("key:value"), false, null, null, null, null
+        );
+
+        Query matchingLabel = Query.builder()
+            .kestraUrl(Property.ofValue(KESTRA_URL))
+            .auth(
+                AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue(USERNAME))
+                    .password(Property.ofValue(PASSWORD))
+                    .build()
+            )
+            .tenantId(Property.ofValue(TENANT_ID))
+            .namespace(Property.ofValue(NAMESPACE))
+            .labels(Property.ofValue(Map.of("key", "value")))
+            .size(Property.ofValue(10))
+            .fetchType(Property.ofValue(io.kestra.core.models.tasks.common.FetchType.FETCH))
+            .build();
+
+        FetchOutput matchingOutput = matchingLabel.run(runContext);
+
+        assertThat(matchingOutput, is(notNullValue()));
+        assertThat(matchingOutput.getSize(), is(greaterThanOrEqualTo(1L)));
+
+        Query nonMatchingLabel = matchingLabel.toBuilder()
+            .labels(Property.ofValue(Map.of("key", "wrong-value")))
+            .build();
+
+        FetchOutput nonMatchingOutput = nonMatchingLabel.run(runContext);
+
+        assertThat(nonMatchingOutput, is(notNullValue()));
+        assertThat(nonMatchingOutput.getSize(), is(0L));
     }
 }


### PR DESCRIPTION
## Summary

- `Query` task's per-label filter construction used `QueryFilterField.STATE` and packed `key + ":" + value` into a single string value, instead of `QueryFilterField.LABELS` with a proper map value.
- This made the backend try to parse the label value as a `State.Type` enum constant, throwing `Illegal argument: No enum constant ...State.Type.<labelKey>` whenever the `labels` property was used.
- Fixed by building the filter with `QueryFilterField.LABELS` and `.value(Map.of(key, value))`, matching the shape used by the backend's execution repository tests.

closes: https://github.com/kestra-io/plugin-kestra/issues/139

## Test plan

- [x] `rtk test ./gradlew test` passes for `QueryTest` (new `shouldSearchExecutionsByLabel` test asserts a labeled execution is matched, and a wrong label value yields zero results)
- [x] `./gradlew shadowJar` builds
- [ ] Note: pre-existing `io.kestra.plugin.kestra.ee.*` tests fail locally because `KESTRA_EE_UNIT_TEST_LICENSE_FILE` isn't set in this environment — unrelated to this change, expected to run fine in CI

---
*[View as Artifact](https://claude.ai/code/artifact/118969b1-17a7-4701-a805-0a0bd12f4a00)*