### PR TITLE
fix(tests): avoid flaky ScheduleMonitorTest timeouts on scheduler init

### DIFF
--- a/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
@@ -87,7 +87,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
             Await.until(
                 () -> evaluate(monitor2, context2.getKey(), context2.getValue()).orElse(null),
                 Duration.ofMillis(100),
-                AWAIT_TIMEOUT
+                INITIAL_AWAIT_TIMEOUT
             )
         );
 

--- a/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
@@ -34,6 +34,9 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
     RunContextFactory runContextFactory;
 
     private static final String NAMESPACE_PREFIX = "kestra.tests.schedule.monitor";
+    // Scheduler initializes trigger state at next minute boundary; allow up to 5 min
+    // to avoid flakiness when container is under load (see ToggleTest for the same pattern).
+    private static final Duration INITIAL_AWAIT_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration AWAIT_TIMEOUT = Duration.ofMinutes(2);
 
     @Test
@@ -51,7 +54,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
         Await.until(
             () -> findTrigger(namespace, flowId),
             Duration.ofMillis(100),
-            AWAIT_TIMEOUT
+            INITIAL_AWAIT_TIMEOUT
         );
 
         ScheduleMonitor monitor1 = ScheduleMonitor.builder()
@@ -110,7 +113,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
                 return findTrigger(namespace, flowId);
             },
             Duration.ofMillis(100),
-            AWAIT_TIMEOUT
+            INITIAL_AWAIT_TIMEOUT
         );
 
         ScheduleMonitor monitor = ScheduleMonitor.builder()
@@ -168,7 +171,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
                 return response.getTotal() >= flowCount ? response : null;
             },
             Duration.ofMillis(100),
-            AWAIT_TIMEOUT
+            INITIAL_AWAIT_TIMEOUT
         );
 
         var monitor = ScheduleMonitor.builder()


### PR DESCRIPTION
## Summary
- CI run [29568990624](https://github.com/kestra-io/plugin-kestra/actions/runs/29568990624/job/87848065929) failed on `main` with `ScheduleMonitorTest.shouldDetectNoExecutionWithinInterval` timing out (`Await failed to terminate within PT2M`), while the same commit passed on a neighboring run — confirmed flaky, not a real regression.
- Root cause: the scheduler's first evaluation of a freshly-created schedule trigger inside the shared Testcontainers Kestra instance can take longer than 2 minutes under CI load (shared container, GC pauses), and the test's initial `Await.until(...)` used the same 2-minute budget as its steady-state awaits.
- Fix: split out a dedicated `INITIAL_AWAIT_TIMEOUT` (5 minutes) for the "wait for scheduler to first persist trigger state" step in all three tests in `ScheduleMonitorTest`, matching the existing precedent in `ToggleTest`. Steady-state awaits keep the original 2-minute timeout. No assertions changed.

## Test plan
- [x] `./gradlew test --tests "*ScheduleMonitorTest*"` passes locally (3/3 tests)
- [x] Diff scoped only to the affected test file