### PR TITLE
fix: bring back inputs in resume task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // kestra API client
-    implementation "io.kestra:kestra-api-client:1.3.1"
+    implementation "io.kestra:kestra-api-client:1.3.2"
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/io/kestra/plugin/kestra/executions/Resume.java
+++ b/src/main/java/io/kestra/plugin/kestra/executions/Resume.java
@@ -1,5 +1,8 @@
 package io.kestra.plugin.kestra.executions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -20,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Schema(
     title = "Resume a paused execution",
-    description = "Resumes a PAUSED execution via the Kestra API. Defaults to the current execution id when executionId is empty."
+    description = "Resumes a PAUSED execution via the Kestra API. Defaults to the current execution id when executionId is empty; optional inputs are forwarded to the resumed run."
 )
 @Plugin(
     examples = {
@@ -40,6 +43,26 @@ import lombok.experimental.SuperBuilder;
                       username: "{{ secret('KESTRA_USERNAME') }}"
                       password: "{{ secret('KESTRA_PASSWORD') }}"
                 """
+        ),
+        @Example(
+            title = "Resume an execution with inputs",
+            full = true,
+            code = """
+                id: resume_execution_with_inputs
+                namespace: company.team
+
+                tasks:
+                  - id: resume_execution
+                    type: io.kestra.plugin.kestra.executions.Resume
+                    executionId: "{{ trigger.executionId }}"
+                    kestraUrl: http://localhost:8080
+                    inputs:
+                      comment: "Approved by automated process"
+                      status: "OK"
+                    auth:
+                      username: "{{ secret('KESTRA_USERNAME') }}"
+                      password: "{{ secret('KESTRA_PASSWORD') }}"
+                """
         )
     }
 )
@@ -52,6 +75,9 @@ public class Resume extends AbstractKestraTask implements RunnableTask<VoidOutpu
     @PluginProperty(group = "advanced")
     private Property<String> executionId;
 
+    @Schema(title = "Inputs to send with resume")
+    private Property<Map<String, Object>> inputs;
+
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
         String rExecutionId = this.executionId != null ? runContext.render(this.executionId).as(String.class).orElse(null) : null;
@@ -63,9 +89,11 @@ public class Resume extends AbstractKestraTask implements RunnableTask<VoidOutpu
         String rTenant = runContext.render(this.tenantId).as(String.class)
             .orElse(runContext.flowInfo().tenantId());
 
+        Map<String, Object> rInputs = runContext.render(this.inputs).asMap(String.class, Object.class);
+
         runContext.logger().info("Resuming execution {}", rExecutionId);
         this.kestraClient(runContext).executions()
-            .resumeExecution(rExecutionId, rTenant);
+            .resumeExecution(rExecutionId, rTenant, new HashMap<>(rInputs));
 
         runContext.logger().debug("Successfully resumed execution {}", rExecutionId);
         return null;

--- a/src/test/java/io/kestra/plugin/kestra/KestraTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/kestra/KestraTestDataUtils.java
@@ -97,6 +97,25 @@ public class KestraTestDataUtils {
         return kestraClient.flows().createFlow(tenantId, flow);
     }
 
+    public FlowWithSource createRandomizedPauseFlowWithInputs(@Nullable String namespace) throws ApiException {
+        String np = namespace != null ? namespace : "default";
+        String flow = """
+            id: random_flow_%s
+            namespace: %s
+
+            tasks:
+              - id: pause
+                type: io.kestra.plugin.core.flow.Pause
+                onResume:
+                  - id: quorum_status
+                    type: STRING
+                    required: true
+            """
+            .formatted(UUID.randomUUID().toString().substring(0, 8).replace("-", "_"), np);
+
+        return kestraClient.flows().createFlow(tenantId, flow);
+    }
+
     public FlowWithSource createRandomizedFlowWithLabel(@Nullable String namespace)
         throws ApiException {
         String np = namespace != null ? namespace : "default";

--- a/src/test/java/io/kestra/plugin/kestra/executions/ResumeTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/executions/ResumeTest.java
@@ -55,6 +55,43 @@ public class ResumeTest extends AbstractKestraOssContainerTest {
     }
 
     @Test
+    public void shouldResumePausedExecutionWithInputs() throws Exception {
+        FlowWithSource flow = kestraTestDataUtils.createRandomizedPauseFlowWithInputs(NAMESPACE);
+        kestraTestDataUtils.createRandomizedExecution(flow.getId(), flow.getNamespace());
+
+        Thread.sleep(1000);
+        var pausedExecution = queryExecution(flow.getId());
+        assertThat(
+            "Execution should start in PAUSED state",
+            pausedExecution.getState().getCurrent(), is(StateType.PAUSED)
+        );
+
+        RunContext runContext = createRunContext(pausedExecution.getId());
+
+        // onResume declares a required input, so resume only succeeds if inputs are forwarded
+        Resume resumeTask = Resume.builder()
+            .kestraUrl(Property.ofValue(KESTRA_URL))
+            .auth(
+                AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue(USERNAME))
+                    .password(Property.ofValue(PASSWORD))
+                    .build()
+            )
+            .tenantId(Property.ofValue(TENANT_ID))
+            .executionId(Property.ofValue(pausedExecution.getId()))
+            .inputs(Property.ofValue(Map.of("quorum_status", "TIMEOUT")))
+            .build();
+        resumeTask.run(runContext);
+
+        Thread.sleep(1000);
+        var resumedExecution = queryExecution(flow.getId());
+        assertThat(
+            "Execution should no longer be PAUSED",
+            resumedExecution.getState().getCurrent(), not(StateType.PAUSED)
+        );
+    }
+
+    @Test
     public void shouldFailToResumeFinishedExecution() throws Exception {
         RunContext runContext = runContextFactory.of();
         FlowWithSource flow = kestraTestDataUtils.createRandomizedFlow(NAMESPACE);


### PR DESCRIPTION
This PR assume that a 1.3.2 SDK will be released

CI probably need to be restarted at this moment