### PR TITLE
test: harden flaky ToggleTest and ScheduleMonitorTest

### DIFF
--- a/src/test/java/io/kestra/plugin/kestra/KestraTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/kestra/KestraTestDataUtils.java
@@ -341,6 +341,45 @@ public class KestraTestDataUtils {
         return kestraClient.testSuites().createTestSuite(tenantId, testSuite);
     }
 
+    /**
+     * Deletes a single flow. Used by tests to clean up flows they created so the shared scheduler
+     * (and its trigger state) doesn't accumulate load across the whole test run.
+     */
+    public void deleteFlow(String namespace, String flowId) {
+        try {
+            kestraClient.flows().deleteFlow(namespace, flowId, tenantId);
+        } catch (ApiException e) {
+            log.error(
+                "ApiException thrown, probably false positive as we are in `deleteFlow` :"
+                    + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Bulk-deletes every flow in a namespace. Preferred over per-flow {@link #deleteFlow} when a
+     * test creates many flows in a single namespace (e.g. pagination tests), since it removes all
+     * their triggers from the scheduler in one call instead of one round-trip per flow.
+     */
+    public void deleteFlowsInNamespace(String namespace) {
+        try {
+            kestraClient.flows().deleteFlowsByQuery(
+                tenantId,
+                List.of(
+                    new QueryFilter()
+                        .field(QueryFilterField.NAMESPACE)
+                        .operation(QueryFilterOp.EQUALS)
+                        .value(namespace)
+                )
+            );
+        } catch (ApiException e) {
+            log.error(
+                "ApiException thrown, probably false positive as we are in `deleteFlowsInNamespace` :"
+                    + e.getMessage()
+            );
+        }
+    }
+
     public FlowWithSource createFlowWithSchedule(String namespace, String flowId, String cron, boolean disabled)
         throws ApiException {
 

--- a/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
@@ -1,10 +1,12 @@
 package io.kestra.plugin.triggers;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -39,10 +41,19 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
     private static final Duration INITIAL_AWAIT_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration AWAIT_TIMEOUT = Duration.ofMinutes(2);
 
+    private final List<String> createdNamespaces = new ArrayList<>();
+
+    @AfterEach
+    void cleanupFlows() {
+        createdNamespaces.forEach(kestraTestDataUtils::deleteFlowsInNamespace);
+        createdNamespaces.clear();
+    }
+
     @Test
     public void shouldDetectDisabledScheduleOnlyWhenIncluded() throws Exception {
         var namespace = randomNamespace();
         var flowId = "myflow-" + IdUtils.create();
+        createdNamespaces.add(namespace);
 
         kestraTestDataUtils.createFlowWithSchedule(
             namespace,
@@ -98,6 +109,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
     public void shouldDetectNoExecutionWithinInterval() throws Exception {
         var namespace = randomNamespace();
         var flowId = "intervalflow-" + IdUtils.create();
+        createdNamespaces.add(namespace);
 
         kestraTestDataUtils.createFlowWithSchedule(
             namespace,
@@ -141,6 +153,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
     public void shouldDetectDisabledSchedulesAcrossPages() throws Exception {
         var namespace = randomNamespace();
         var flowCount = 101;
+        createdNamespaces.add(namespace);
 
         for (var i = 0; i < flowCount; i++) {
             kestraTestDataUtils.createFlowWithSchedule(

--- a/src/test/java/io/kestra/plugin/kestra/triggers/ToggleTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/triggers/ToggleTest.java
@@ -1,7 +1,10 @@
 package io.kestra.plugin.kestra.triggers;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -27,8 +30,15 @@ class ToggleTest extends AbstractKestraOssContainerTest {
     private static final String NAMESPACE = "kestra.tests.trigger.toggle";
     private static final String FLOW_ID = "toggle-flow";
     private static final String TRIGGER_ID = "schedule";
-    private static final Duration INITIAL_AWAIT_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration AWAIT_TIMEOUT = Duration.ofMinutes(2);
+
+    private final List<String> createdFlowIds = new ArrayList<>();
+
+    @AfterEach
+    void cleanupFlows() {
+        createdFlowIds.forEach(flowId -> kestraTestDataUtils.deleteFlow(NAMESPACE, flowId));
+        createdFlowIds.clear();
+    }
 
     @Test
     void shouldDisableAndEnableTrigger() throws Exception {
@@ -41,14 +51,7 @@ class ToggleTest extends AbstractKestraOssContainerTest {
             "* * * * *",
             false
         );
-
-        // Scheduler initializes trigger state at next minute boundary; allow up to 5 min
-        // to avoid flakiness when container is under load (e.g. concurrent 101-flow test).
-        Await.until(
-            () -> findTrigger(flowId),
-            Duration.ofSeconds(1),
-            INITIAL_AWAIT_TIMEOUT
-        );
+        createdFlowIds.add(flowId);
 
         Toggle disable = Toggle.builder()
             .id("disable-" + IdUtils.create())


### PR DESCRIPTION
## Problem

`ToggleTest.shouldDisableAndEnableTrigger` intermittently fails in CI with:

```
java.util.concurrent.TimeoutException: Await failed to terminate within PT5M.
src/test/java/io/kestra/plugin/kestra/triggers/ToggleTest.java:47
```
(e.g. [run 29803044138](https://github.com/kestra-io/plugin-kestra/actions/runs/29803044138/job/88547736390) — 56/57 passed, this one timed out at 301s).

## Root cause

All OSS tests share **one static Kestra container** (`AbstractKestraOssContainerTest`) running `server local` with a JDBC scheduler. Every schedule trigger created during the whole test run accumulates in that single scheduler — including the **101 flows** from `ScheduleMonitorTest.shouldDetectDisabledSchedulesAcrossPages` plus several `* * * * *` flows — and **nothing is ever cleaned up**. `ToggleTest` waited (up to 5 min) for the scheduler to register a newly-created trigger's runtime state; late in the suite the scheduler's evaluation loop is backed up enough that registration exceeds the timeout. The 5-minute budget was a band-aid on a load problem that only grows.

The initial await was also **unnecessary**: `Toggle`'s `disabledTriggersByQuery` API upserts the trigger's `disabled` state directly, immediately readable via `searchTriggersForFlow`, with no dependency on the scheduler's per-minute cycle.

## Changes (test-only — no `src/main` touched)

- **Remove** the dead 5-minute initial await from `ToggleTest`.
- **Add** `deleteFlow` / `deleteFlowsInNamespace` helpers to `KestraTestDataUtils` (both swallow/log `ApiException` like existing helpers).
- **Clean up** created flows via `@AfterEach` in `ToggleTest` and `ScheduleMonitorTest`, so the shared scheduler stays lean across the run.
- `ScheduleMonitorTest`'s `INITIAL_AWAIT` is kept — those tests genuinely read scheduler-populated state.

## Verification

Ran twice locally, all green (`failures=0 errors=0`):

| | ToggleTest | ScheduleMonitorTest (3 tests) |
|---|---|---|
| Run 1 | PASS 0.688s | PASS 7.756s |
| Run 2 | PASS | PASS 7.853s |

`ToggleTest` now runs in ~0.7s instead of blocking up to 5 min. Cleanup confirmed in logs: 103 flow creates balanced by 3 bulk deletes (ScheduleMonitorTest) + per-flow delete (ToggleTest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)