### PR TITLE
test: restore trigger-registration await in ToggleTest

### DIFF
--- a/src/test/java/io/kestra/plugin/kestra/triggers/ToggleTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/triggers/ToggleTest.java
@@ -30,6 +30,9 @@ class ToggleTest extends AbstractKestraOssContainerTest {
     private static final String NAMESPACE = "kestra.tests.trigger.toggle";
     private static final String FLOW_ID = "toggle-flow";
     private static final String TRIGGER_ID = "schedule";
+    // Scheduler registers the trigger state row at the next minute boundary; allow up to 5 min
+    // so registration survives a scheduler backlog on the shared container.
+    private static final Duration INITIAL_AWAIT_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration AWAIT_TIMEOUT = Duration.ofMinutes(2);
 
     private final List<String> createdFlowIds = new ArrayList<>();
@@ -52,6 +55,14 @@ class ToggleTest extends AbstractKestraOssContainerTest {
             false
         );
         createdFlowIds.add(flowId);
+
+        // Toggle's disabledTriggersByQuery only updates trigger-state rows that already exist, so
+        // wait for the scheduler to register the trigger before toggling it.
+        Await.until(
+            () -> findTrigger(flowId),
+            Duration.ofSeconds(1),
+            INITIAL_AWAIT_TIMEOUT
+        );
 
         Toggle disable = Toggle.builder()
             .id("disable-" + IdUtils.create())


### PR DESCRIPTION
## Context

PR #164 hardened the flaky `ToggleTest` / `ScheduleMonitorTest`, but after merge the `main` push CI failed at `ToggleTest.java:70` with `TimeoutException: Await failed to terminate within PT2M` (run [29808625531](https://github.com/kestra-io/plugin-kestra/actions/runs/29808625531/job/88564473782)).

## Root cause

#164 removed ToggleTest's initial await on the assumption that `Toggle`'s `disabledTriggersByQuery` API upserts the trigger's disabled state directly, making it immediately readable regardless of scheduler timing.

That assumption is wrong: `disabledTriggersByQuery` only **updates** trigger-state rows that already exist. On a freshly created flow the scheduler hasn't yet registered the trigger, so the disable call matches **0 triggers**, and the subsequent await for `disabled=true` times out — the scheduler later registers the trigger as `disabled=false` (from the flow definition), which the await never accepts.

## Fix

Restore the initial `Await.until(() -> findTrigger(flowId), …)` so we wait for the scheduler to register the trigger before toggling it. The `@AfterEach` cleanup added in #164 stays, keeping the shared scheduler lean so registration remains fast across the run.

Verified locally: `ToggleTest` passes (1 passing, ~15s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)