### PR TITLE
feat: add CreateCase task for Cases incident management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // kestra API client
-    implementation "io.kestra:kestra-api-client:1.3.2"
+    implementation "io.kestra:kestra-api-client:1.3.2-cases-SNAPSHOT"
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/io/kestra/plugin/kestra/ee/cases/CreateCase.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/cases/CreateCase.java
@@ -1,0 +1,287 @@
+package io.kestra.plugin.kestra.ee.cases;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.ListOrMapOfLabelDeserializer;
+import io.kestra.core.serializers.ListOrMapOfLabelSerializer;
+import io.kestra.core.validations.NoSystemLabelValidation;
+import io.kestra.plugin.kestra.AbstractKestraTask;
+import io.kestra.sdk.model.CaseSeverity;
+import io.kestra.sdk.model.CaseStatus;
+import io.kestra.sdk.model.CasesControllerCaseFromTaskRequest;
+import io.kestra.sdk.model.SlaConfig;
+import io.kestra.sdk.model.Subjects;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Open an incident-management Case, or attach the current execution to an already-open matching one.",
+    description = """
+        Creates a new Case in Kestra's incident-management feature, typically from an `errors:` task so an incident \
+        is opened whenever a flow fails. The execution that triggered the task is automatically linked to the case.
+
+        When `linkMatchingExecutions` is `true`, the task first looks for an active (non-resolved, non-cancelled) \
+        case previously created by this same task (same flow + task id); if one is found, the triggering execution \
+        is attached to it instead of creating a new case."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Open a case when a flow fails.",
+            full = true,
+            code = """
+                id: health_check
+                namespace: company.team
+
+                tasks:
+                  - id: check
+                    type: io.kestra.plugin.core.http.Request
+                    uri: https://example.com/health
+
+                errors:
+                  - id: open_incident
+                    type: io.kestra.plugin.kestra.ee.cases.CreateCase
+                    title: "{{ execution.id }} failed for {{ flow.id }}"
+                    caseDescription: "Health check failed."
+                    severity: CRITICAL
+                    sla:
+                      acknowledgement: PT1H
+                      resolution: PT8H
+                    linkMatchingExecutions: true
+                    assignees:
+                      users:
+                        - a@b.c
+                      groups:
+                        - Admins
+                """
+        )
+    }
+)
+public class CreateCase extends AbstractKestraTask implements RunnableTask<CreateCase.Output> {
+
+    @Schema(
+        title = "Namespace the case belongs to",
+        description = "Defaults to the flow's namespace."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> namespace;
+
+    @NotNull
+    @Schema(title = "Case title")
+    @PluginProperty(group = "main")
+    private Property<String> title;
+
+    @Schema(title = "Case description", description = "Supports Markdown.")
+    @PluginProperty(group = "main")
+    private Property<String> caseDescription;
+
+    @Schema(title = "Case severity", description = "Defaults to `MEDIUM` if not set.")
+    @PluginProperty(group = "main")
+    private Property<CaseSeverity> severity;
+
+    @Schema(title = "Initial case status")
+    @Builder.Default
+    @PluginProperty(group = "main")
+    private Property<CaseStatus> status = Property.ofValue(CaseStatus.OPEN);
+
+    @Schema(title = "SLA targets for the case")
+    @PluginProperty(group = "main")
+    private SlaProperty sla;
+
+    @Schema(
+        title = "Attach to a matching open case instead of creating a new one",
+        description = "When `true`, looks for an active (non-resolved, non-cancelled) case previously created by this same task and attaches the triggering execution to it instead of creating a new case."
+    )
+    @Builder.Default
+    @PluginProperty(group = "main")
+    private Property<Boolean> linkMatchingExecutions = Property.ofValue(false);
+
+    @Schema(title = "Assignees")
+    @PluginProperty(group = "main")
+    private SubjectsProperty assignees;
+
+    @Schema(title = "Watchers")
+    @PluginProperty(group = "main")
+    private SubjectsProperty watchers;
+
+    @Schema(title = "Asset IDs to link to the case")
+    @PluginProperty(group = "main")
+    private Property<List<String>> assetIds;
+
+    @Schema(
+        title = "Labels to attach to the case",
+        description = "Labels as a list of Label (key/value pairs) or as a map of string to string.",
+        implementation = Object.class,
+        oneOf = {
+            Label[].class,
+            Map.class
+        }
+    )
+    @PluginProperty(group = "main")
+    @JsonSerialize(using = ListOrMapOfLabelSerializer.class)
+    @JsonDeserialize(using = ListOrMapOfLabelDeserializer.class)
+    private List<@NoSystemLabelValidation Label> labels;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        RunContext.FlowInfo flowInfo = runContext.flowInfo();
+        RunContext.TaskRunInfo taskRunInfo = runContext.taskRunInfo();
+
+        String rTenantId = runContext.render(tenantId).as(String.class).orElse(flowInfo.tenantId());
+        String rNamespace = runContext.render(namespace).as(String.class).orElse(flowInfo.namespace());
+        String rTitle = runContext.render(title).as(String.class).orElseThrow();
+        String rDescription = runContext.render(caseDescription).as(String.class).orElse(null);
+        CaseSeverity rSeverity = runContext.render(severity).as(CaseSeverity.class).orElse(null);
+        CaseStatus rStatus = runContext.render(status).as(CaseStatus.class).orElse(CaseStatus.OPEN);
+        boolean rLinkMatchingExecutions = runContext.render(linkMatchingExecutions).as(Boolean.class).orElse(false);
+        SlaConfig rSla = renderSla(runContext);
+        Subjects rAssignees = renderSubjects(runContext, assignees);
+        Subjects rWatchers = renderSubjects(runContext, watchers);
+        List<String> rAssetIds = assetIds != null ? runContext.render(assetIds).asList(String.class) : List.of();
+        List<io.kestra.sdk.model.Label> rLabels = renderLabels(runContext);
+
+        String executionId = taskRunInfo.executionId();
+        String executionState = currentExecutionState(runContext);
+
+        CasesControllerCaseFromTaskRequest request = new CasesControllerCaseFromTaskRequest()
+            .namespace(rNamespace)
+            .title(rTitle)
+            .description(rDescription)
+            .severity(rSeverity)
+            .status(rStatus)
+            .sla(rSla)
+            .assignees(rAssignees)
+            .watchers(rWatchers)
+            .labels(rLabels.isEmpty() ? null : rLabels)
+            .assetIds(rAssetIds.isEmpty() ? null : rAssetIds)
+            .linkMatchingExecutions(rLinkMatchingExecutions)
+            .flowNamespace(flowInfo.namespace())
+            .flowId(flowInfo.id())
+            .taskId(this.id)
+            .executionId(executionId)
+            .executionState(executionState);
+
+        Map<String, Object> result = kestraClient(runContext).cases().createFromTask(rTenantId, request);
+
+        return Output.builder()
+            .caseId((String) result.get("caseId"))
+            .created((Boolean) result.get("created"))
+            .build();
+    }
+
+    private SlaConfig renderSla(RunContext runContext) throws Exception {
+        if (sla == null) {
+            return null;
+        }
+
+        Duration acknowledgement = sla.getAcknowledgement() != null
+            ? runContext.render(sla.getAcknowledgement()).as(Duration.class).orElse(null)
+            : null;
+        Duration resolution = sla.getResolution() != null
+            ? runContext.render(sla.getResolution()).as(Duration.class).orElse(null)
+            : null;
+
+        if (acknowledgement == null && resolution == null) {
+            return null;
+        }
+        return new SlaConfig()
+            .acknowledgement(acknowledgement != null ? acknowledgement.toString() : null)
+            .resolution(resolution != null ? resolution.toString() : null);
+    }
+
+    private Subjects renderSubjects(RunContext runContext, SubjectsProperty subjects) throws Exception {
+        if (subjects == null) {
+            return null;
+        }
+
+        List<String> users = subjects.getUsers() != null ? runContext.render(subjects.getUsers()).asList(String.class) : List.of();
+        List<String> groups = subjects.getGroups() != null ? runContext.render(subjects.getGroups()).asList(String.class) : List.of();
+        return new Subjects().users(users).groups(groups);
+    }
+
+    private List<io.kestra.sdk.model.Label> renderLabels(RunContext runContext) throws Exception {
+        if (labels == null) {
+            return List.of();
+        }
+
+        List<io.kestra.sdk.model.Label> rendered = new ArrayList<>();
+        for (Label label : labels) {
+            rendered.add(new io.kestra.sdk.model.Label()
+                .key(runContext.render(label.key()))
+                .value(runContext.render(label.value())));
+        }
+        return rendered;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String currentExecutionState(RunContext runContext) {
+        Object executionVar = runContext.getVariables().get("execution");
+        if (executionVar instanceof Map<?, ?> executionMap) {
+            Object state = executionMap.get("state");
+            return state != null ? state.toString() : null;
+        }
+        return null;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @ToString
+    public static class SubjectsProperty {
+        @Schema(title = "User emails")
+        private Property<List<String>> users;
+
+        @Schema(title = "Group names")
+        private Property<List<String>> groups;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @ToString
+    public static class SlaProperty {
+        @Schema(title = "Time to acknowledge, counted from case creation")
+        private Property<Duration> acknowledgement;
+
+        @Schema(title = "Time to resolve, counted from case creation")
+        private Property<Duration> resolution;
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "The id of the case that was created or attached to")
+        private String caseId;
+
+        @Schema(title = "Whether a new case was created", description = "`false` if the triggering execution was attached to an existing matching case instead.")
+        private Boolean created;
+    }
+}

--- a/src/main/java/io/kestra/plugin/kestra/ee/cases/package-info.java
+++ b/src/main/java/io/kestra/plugin/kestra/ee/cases/package-info.java
@@ -1,0 +1,6 @@
+@PluginSubGroup(
+    title = "Kestra Cases", categories = { PluginSubGroup.PluginCategory.CORE }
+)
+package io.kestra.plugin.kestra.ee.cases;
+
+import io.kestra.core.models.annotations.PluginSubGroup;

--- a/src/test/java/io/kestra/plugin/kestra/ee/cases/CreateCaseSchemaTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/ee/cases/CreateCaseSchemaTest.java
@@ -1,0 +1,33 @@
+package io.kestra.plugin.kestra.ee.cases;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.docs.JsonSchemaGenerator;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.tasks.Task;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class CreateCaseSchemaTest {
+
+    @Inject
+    JsonSchemaGenerator jsonSchemaGenerator;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void labelsAcceptsListOrMap() {
+        Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, CreateCase.class);
+        var properties = (Map<String, Map<String, Object>>) generate.get("properties");
+        Map<String, Object> labels = properties.get("labels");
+
+        // oneOf renders as "anyOf" in JSON schema; its absence is what made the editor reject the map form.
+        assertThat(labels).containsKey("anyOf");
+        String rendered = labels.toString();
+        assertThat(rendered).contains("array").contains("object");
+    }
+}

--- a/src/test/java/io/kestra/plugin/kestra/ee/cases/CreateCaseTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/ee/cases/CreateCaseTest.java
@@ -1,0 +1,64 @@
+package io.kestra.plugin.kestra.ee.cases;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.kestra.AbstractKestraEeContainerTest;
+import io.kestra.plugin.kestra.AbstractKestraTask;
+import io.kestra.sdk.model.CaseSeverity;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class CreateCaseTest extends AbstractKestraEeContainerTest {
+    protected static final String NAMESPACE = "kestra.tests.cases.create";
+
+    @Inject
+    TestRunContextFactory runContextFactory;
+
+    @Test
+    void createsCaseAndLinksMatchingExecutionOnSecondRun() throws Exception {
+        String taskId = "open_incident_" + IdUtils.create();
+        String title = "Health check failed for " + IdUtils.create();
+
+        CreateCase createCase = CreateCase.builder()
+            .id(taskId)
+            .type(CreateCase.class.getName())
+            .kestraUrl(Property.ofValue(KESTRA_URL))
+            .auth(
+                AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue(USERNAME))
+                    .password(Property.ofValue(PASSWORD))
+                    .build()
+            )
+            .tenantId(Property.ofValue(TENANT_ID))
+            .namespace(Property.ofValue(NAMESPACE))
+            .title(Property.ofExpression("{{ inputs.title }}"))
+            .severity(Property.ofValue(CaseSeverity.CRITICAL))
+            .linkMatchingExecutions(Property.ofValue(true))
+            .build();
+
+        RunContext firstRunContext = TestsUtils.mockRunContext(
+            this.runContextFactory, createCase, java.util.Map.of("title", title)
+        );
+        CreateCase.Output firstOutput = createCase.run(firstRunContext);
+
+        assertThat(firstOutput.getCaseId()).isNotBlank();
+        assertThat(firstOutput.getCreated()).isTrue();
+
+        RunContext secondRunContext = TestsUtils.mockRunContext(
+            this.runContextFactory, createCase, java.util.Map.of("title", title)
+        );
+        CreateCase.Output secondOutput = createCase.run(secondRunContext);
+
+        assertThat(secondOutput.getCaseId()).isEqualTo(firstOutput.getCaseId());
+        assertThat(secondOutput.getCreated()).isFalse();
+    }
+}


### PR DESCRIPTION
- Adds `io.kestra.plugin.kestra.ee.cases.CreateCase`, a task that opens a Case (or attaches to a matching open one, when `linkMatchingExecutions: true`) via the Cases API — typically used under `errors:` so an incident is opened whenever a flow fails
- SLA targets (`acknowledgement`, `resolution`) are both counted from case creation
- Pinned to a local `kestra-api-client` SNAPSHOT until the client-sdk Cases bindings PR (kestra-io/client-sdk#370) merges and publishes a real version

Companion to kestra-ee PR #9383 (Cases feature) and client-sdk PR #370.