### PR TITLE
chore: bump kestraVersion to 2.0.0-rc9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,19 @@ permissions:
   packages: read
 
 jobs:
+  detect-version:
+    runs-on: ubuntu-latest
+    outputs:
+      kestra-version: ${{ steps.read.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: echo "version=$(grep '^kestraVersion=' gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+
   check:
+    needs: detect-version
     uses: kestra-io/actions/.github/workflows/plugins.yml@main
     with:
       skip-test: ${{ github.event.inputs.skip-test == 'true' }}
-      kestra-version: ${{ github.event.inputs.kestra-version }}
+      kestra-version: ${{ github.event.inputs.kestra-version != '' && github.event.inputs.kestra-version || needs.detect-version.outputs.kestra-version }}
     secrets: inherit

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
     }
 }
 
-final targetJavaVersion = JavaVersion.VERSION_21
+final targetJavaVersion = JavaVersion.VERSION_25
 
 java {
     sourceCompatibility = targetJavaVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.11.5-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=2.0.0-rc9

--- a/src/test/java/io/kestra/plugin/kestra/ee/assets/FreshnessTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/ee/assets/FreshnessTriggerTest.java
@@ -18,8 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.triggers.Trigger;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.kestra.AbstractKestraEeContainerTest;
@@ -71,8 +71,8 @@ public class FreshnessTriggerTest extends AbstractKestraEeContainerTest {
             )
         );
 
-        Map.Entry<ConditionContext, Trigger> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
-        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue());
+        Map.Entry<ConditionContext, TriggerState> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
+        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue().context());
 
         assertThat(evaluate.isPresent(), is(true));
         List<Map<String, Object>> triggerOutputAssets = (List<Map<String, Object>>) evaluate.get().getTrigger().getVariables().get("assets");
@@ -146,8 +146,8 @@ public class FreshnessTriggerTest extends AbstractKestraEeContainerTest {
         Instant triggerTime = Instant.now().plus(Duration.ofHours(1));
         Mockito.doReturn(triggerTime).when(clock).instant();
 
-        Map.Entry<ConditionContext, Trigger> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
-        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue());
+        Map.Entry<ConditionContext, TriggerState> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
+        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue().context());
 
         assertThat(evaluate.isPresent(), is(true));
         List<Map<String, Object>> triggerOutputAssets = (List<Map<String, Object>>) evaluate.get().getTrigger().getVariables().get("assets");
@@ -179,8 +179,8 @@ public class FreshnessTriggerTest extends AbstractKestraEeContainerTest {
         Instant triggerTime = Instant.now().plus(Duration.ofHours(1));
         Mockito.doReturn(triggerTime).when(clock).instant();
 
-        Map.Entry<ConditionContext, Trigger> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
-        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue());
+        Map.Entry<ConditionContext, TriggerState> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
+        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue().context());
 
         assertThat(evaluate.isPresent(), is(true));
         List<Map<String, Object>> triggerOutputAssets = (List<Map<String, Object>>) evaluate.get().getTrigger().getVariables().get("assets");
@@ -213,8 +213,8 @@ public class FreshnessTriggerTest extends AbstractKestraEeContainerTest {
         Instant triggerTime = Instant.now().plus(Duration.ofHours(1));
         Mockito.doReturn(triggerTime).when(clock).instant();
 
-        Map.Entry<ConditionContext, Trigger> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
-        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue());
+        Map.Entry<ConditionContext, TriggerState> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
+        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue().context());
 
         assertThat(evaluate.isPresent(), is(true));
         List<Map<String, Object>> triggerOutputAssets = (List<Map<String, Object>>) evaluate.get().getTrigger().getVariables().get("assets");
@@ -236,7 +236,7 @@ public class FreshnessTriggerTest extends AbstractKestraEeContainerTest {
             .clock(clock)
             .build();
 
-        evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue());
+        evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue().context());
 
         assertThat(evaluate.isPresent(), is(true));
         triggerOutputAssets = (List<Map<String, Object>>) evaluate.get().getTrigger().getVariables().get("assets");
@@ -266,8 +266,8 @@ public class FreshnessTriggerTest extends AbstractKestraEeContainerTest {
         Instant triggerTime = Instant.now().plus(Duration.ofHours(1));
         Mockito.doReturn(triggerTime).when(clock).instant();
 
-        Map.Entry<ConditionContext, Trigger> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
-        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue());
+        Map.Entry<ConditionContext, TriggerState> conditionContextTriggerEntry = TestsUtils.mockTrigger(runContextFactory, freshnessTrigger);
+        Optional<Execution> evaluate = freshnessTrigger.evaluate(conditionContextTriggerEntry.getKey(), conditionContextTriggerEntry.getValue().context());
 
         assertThat(evaluate.isPresent(), is(true));
         List<Map<String, Object>> triggerOutputAssets = (List<Map<String, Object>>) evaluate.get().getTrigger().getVariables().get("assets");

--- a/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
+++ b/src/test/java/io/kestra/plugin/kestra/triggers/ScheduleMonitorTest.java
@@ -78,8 +78,8 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
             .includeDisabled(Property.ofValue(false))
             .build();
 
-        Map.Entry<ConditionContext, io.kestra.core.models.triggers.Trigger> context = TestsUtils.mockTrigger(runContextFactory, monitor1);
-        Optional<Execution> execution = monitor1.evaluate(context.getKey(), context.getValue());
+        Map.Entry<ConditionContext, io.kestra.core.scheduler.model.TriggerState> context = TestsUtils.mockTrigger(runContextFactory, monitor1);
+        Optional<Execution> execution = monitor1.evaluate(context.getKey(), context.getValue().context());
 
         assertThat(execution.isPresent(), is(false));
 
@@ -138,7 +138,7 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
             .maxExecutionInterval(Property.ofValue(Duration.ofSeconds(1)))
             .build();
 
-        Map.Entry<ConditionContext, io.kestra.core.models.triggers.Trigger> context = TestsUtils.mockTrigger(runContextFactory, monitor);
+        Map.Entry<ConditionContext, io.kestra.core.scheduler.model.TriggerState> context = TestsUtils.mockTrigger(runContextFactory, monitor);
 
         var execution = Await.until(
             () -> evaluate(monitor, context.getKey(), context.getValue()).orElse(null),
@@ -213,9 +213,9 @@ public class ScheduleMonitorTest extends AbstractKestraOssContainerTest {
     private Optional<Execution> evaluate(
         ScheduleMonitor monitor,
         ConditionContext conditionContext,
-        io.kestra.core.models.triggers.Trigger triggerContext) {
+        io.kestra.core.scheduler.model.TriggerState triggerState) {
         try {
-            return monitor.evaluate(conditionContext, triggerContext);
+            return monitor.evaluate(conditionContext, triggerState.context());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Summary
- Bump `kestraVersion` in `gradle.properties` from `1.3.13` to `2.0.0-rc9`

Extracted from main (was pushed directly, now routed through PR).